### PR TITLE
Adding Oxygen level config option

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -275,7 +275,7 @@ end)
 
 RegisterNetEvent("qb-diving:client:setoxygenlevel", function()
     if oxygenLevel == 0 then
-        oxygenLevel = 100 -- oxygenlevel
+        oxygenLevel = Config.OxygenLevel -- oxygenlevel
         exports.qbx_core:Notify(Lang:t("success.tube_filled"), 'success')
         TriggerServerEvent('qb-diving:server:removeItemAfterFill')
         return

--- a/client/main.lua
+++ b/client/main.lua
@@ -348,7 +348,12 @@ RegisterNetEvent('qb-diving:client:UseGear', function()
             currentGear.enabled = true
             TriggerServerEvent("InteractSound_SV:PlayOnSource", "breathdivingsuit", 0.25)
             CreateThread(function()
-                while currentGear.enabled and IsPedSwimmingUnderWater(cache.ped) do
+                while currentGear.enabled and oxygenLevel > 0 do
+                    oxygenLevel -= 1
+                    if oxygenLevel % 10 == 0 and oxygenLevel ~= Config.OxygenLevel then
+                        TriggerServerEvent("InteractSound_SV:PlayOnSource", "breathdivingsuit", 0.25)
+                    end
+                    if oxygenLevel == 0 then
                     oxygenLevel -= 1
                     if oxygenLevel % 10 == 0 and oxygenLevel ~= Config.OxygenLevel then
                         TriggerServerEvent("InteractSound_SV:PlayOnSource", "breathdivingsuit", 0.25)

--- a/client/main.lua
+++ b/client/main.lua
@@ -349,7 +349,7 @@ RegisterNetEvent('qb-diving:client:UseGear', function()
             TriggerServerEvent("InteractSound_SV:PlayOnSource", "breathdivingsuit", 0.25)
             CreateThread(function()
                 while currentGear.enabled do
-                    if oxygenLevel > 0 then
+                    if IsPedSwimmingUnderWater(cache.ped) and oxygenLevel > 0 then
                         oxygenLevel -= 1
                         if oxygenLevel % 10 == 0 and oxygenLevel ~= Config.OxygenLevel then
                             TriggerServerEvent("InteractSound_SV:PlayOnSource", "breathdivingsuit", 0.25)

--- a/client/main.lua
+++ b/client/main.lua
@@ -350,7 +350,7 @@ RegisterNetEvent('qb-diving:client:UseGear', function()
             CreateThread(function()
                 while currentGear.enabled and IsPedSwimmingUnderWater(cache.ped) do
                     oxygenLevel -= 1
-                    if oxygenLevel % 10 == 0 and oxygenLevel ~= 100 then
+                    if oxygenLevel % 10 == 0 and oxygenLevel ~= Config.OxygenLevel then
                         TriggerServerEvent("InteractSound_SV:PlayOnSource", "breathdivingsuit", 0.25)
                     elseif oxygenLevel == 0 then
                         SetEnableScuba(cache.ped, false)

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,7 @@
 Config = Config or {}
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target interactions (don't change this, go to your server.cfg and add `setr UseTarget true` to use this and just that from true to false or the other way around)
 Config.CopsChance = 0.5 -- The chance of the cops getting called when a coral gets picked up, this ranges from 0.0 to 1.0
+Config.OxygenLevel = 100
 Config.CoralLocations = {
     [1] = {
         label = "This is Location 1",

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,7 @@
 Config = Config or {}
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target interactions (don't change this, go to your server.cfg and add `setr UseTarget true` to use this and just that from true to false or the other way around)
 Config.CopsChance = 0.5 -- The chance of the cops getting called when a coral gets picked up, this ranges from 0.0 to 1.0
-Config.OxygenLevel = 100
+Config.OxygenLevel = 100 -- in seconds 
 Config.CoralLocations = {
     [1] = {
         label = "This is Location 1",


### PR DESCRIPTION
## Description

Added a config option to change the oxygen level via the config so it can be set without editing the main client file.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
