### PR TITLE
refactor: remove PickedUp config field 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "Lua.diagnostics.globals": [
+        "cache",
+        "lib"
+    ]
+}

--- a/client/main.lua
+++ b/client/main.lua
@@ -68,7 +68,7 @@ local function takeCoral(coral)
         }
     }) then
         Config.CoralLocations[currentDivingLocation.area].corals[coral].PickedUp = true
-        TriggerServerEvent('qb-diving:server:TakeCoral', currentDivingLocation.area, coral, true)
+        TriggerServerEvent('qb-diving:server:TakeCoral', currentDivingLocation.area, coral)
     end
 
     ClearPedTasks(cache.ped)
@@ -248,8 +248,9 @@ RegisterNetEvent('qb-diving:client:NewLocations', function()
     setDivingLocation(area)
 end)
 
-RegisterNetEvent('qb-diving:client:UpdateCoral', function(area, coral, bool)
-    Config.CoralLocations[area].corals[coral].PickedUp = bool
+RegisterNetEvent('qbx_diving:client:coralTaken', function(area, coralIndex)
+    --- TODO: remove zone at area, and coralIndex
+    Config.CoralLocations[area].corals[coralIndex].PickedUp = true
 end)
 
 RegisterNetEvent('qb-diving:client:CallCops', function(coords, msg)

--- a/config.lua
+++ b/config.lua
@@ -7,7 +7,6 @@ Config.Debug = false -- shows outline of box zones
 ---@class Coral
 ---@field coords vector3
 ---@field boxDimensions vector4
----@field PickedUp boolean
 
 ---@class CoralLocation
 ---@field blip vector3
@@ -22,22 +21,18 @@ Config.CoralLocations = {
             {
                 coords = vec3(-2849.25, -377.58, -40.23),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(-2838.43, -363.63, -39.45),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(-2887.04, -394.87, -40.91),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(-2808.99, -385.56, -39.32),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             }
         },
         maxHarvestAmount = 4,
@@ -48,17 +43,14 @@ Config.CoralLocations = {
             {
                 coords = vec3(-3275.03, -38.58, -19.21),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(-3273.73, -76.0, -26.81),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(-3346.53, -50.4, -35.84),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
         },
         maxHarvestAmount = 3,
@@ -69,17 +61,14 @@ Config.CoralLocations = {
             {
                 coords = vec3(-3388.01, 1635.88, -39.41),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(-3354.19, 1549.3, -38.21),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(-3326.04, 1636.43, -40.98),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
         },
         maxHarvestAmount = 3,
@@ -90,17 +79,14 @@ Config.CoralLocations = {
             {
                 coords = vec3(2978.05, -1509.07, -24.96),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(3004.42, -1576.95, -29.36),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(2951.65, -1560.69, -28.36),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
         },
         maxHarvestAmount = 3,
@@ -111,22 +97,18 @@ Config.CoralLocations = {
             {
                 coords = vec3(3421.69, 1976.54, -50.64),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(3424.07, 1957.46, -53.04),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(3434.65, 1993.73, -49.84),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(3415.42, 1965.25, -52.04),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
         },
         maxHarvestAmount = 4,
@@ -137,22 +119,18 @@ Config.CoralLocations = {
             {
                 coords = vec3(2724.0, -2134.95, -19.33),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(2710.68, -2156.06, -18.63),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(2702.84, -2139.29, -18.51),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(2736.27, -2153.91, -20.88),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
         },
         maxHarvestAmount = 4,
@@ -163,22 +141,18 @@ Config.CoralLocations = {
             {
                 coords = vec3(542.31, 7245.37, -30.01),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(528.21, 7223.26, -29.51),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(510.36, 7254.97, -32.11),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
             {
                 coords = vec3(525.37, 7259.12, -30.51),
                 boxDimensions = vec4(3, 3, 5, 100.0),
-                PickedUp = false,
             },
         },
         maxHarvestAmount = 4,


### PR DESCRIPTION
- server holds information about picked up coral in a set of coralIndexes now instead of tracking on the config and syncing to the client
- client is synced this info, but does not store it; instead taking action immediately in the form of deleting targetable coral zones. This makes it so the client need only maintain targetable zone state based on which corals have been picked up.
- Reduced number of network calls between client/server to streamline interactions
- Extracted some functions to increase code re-use and make the code more readable