### PR TITLE
Update main.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,56 @@
+
+![image](https://github.com/alberttheprince/qbx_diving/assets/85725579/d6c057b4-3cce-4522-8166-754bb2d35f4f)
+
 # qbx_diving
 
-Diving Script For qbx_core
+Collect and sell coral with qbx_diving, a coral/item collection resource that's easy to modify and build on.
 
-# [VIDEO]
-https://youtu.be/pPYsy1tKPVM (needs an update after ox conversion)
+Recommended Resources:
+- [qbx_divegear](https://github.com/Qbox-project/qbx_divegear) (if you want to be able to breathe underwater...)
+
+# Features
+
+- 17 unique coral collection areas (all collection points tied to actual coral models)
+- Larger coral reefs split into smaller patches (marked in config if you'd like to combine them)
+- Debug mode for showing coral box zones for adjusting target area
+- Variable chance for coral spawns
+- Limits on coral harvesting before zones change
+- Automatic zone changes if a zone isn't harvested
+
+https://github.com/alberttheprince/qbx_diving/assets/85725579/8e2cbdd1-6786-462d-9a48-741977098283
+
+# Ox_Inventory items
+
+Add the following items to your items.lua file if you don't have them already in ox_inventory:
+
+```
+    ['antipatharia_coral'] = {
+        label = 'Antipatharia',
+        weight = 1000,
+        stack = true,
+        close = true,
+        description = "Also known as black corals or thorn corals."
+    },
+
+    ['dendrogyra_coral'] = {
+        label = 'Dendrogyra',
+        weight = 1000,
+        stack = true,
+        close = true,
+        description = "Also known as a pillar coral."
+    },
+```
+
+# Images
+
+Collecting coral:
+
+![image](https://github.com/alberttheprince/qbx_diving/assets/85725579/32e8a3dc-2b94-4776-983c-2dbb02b05239)
+
+How debug zones appear when turned on:
+
+![image](https://github.com/alberttheprince/qbx_diving/assets/85725579/29199968-ab23-4d64-9018-7b675f88abba)
+
+How the blip appears on the world map:
+
+![image](https://github.com/alberttheprince/qbx_diving/assets/85725579/200f7e93-5a96-4651-8e7f-17e169ed250a)

--- a/client/main.lua
+++ b/client/main.lua
@@ -60,6 +60,7 @@ local function createAreaBlips(areaIndex)
     local radiusBlip = AddBlipForRadius(coords.x, coords.y, coords.z, 100.0)
     SetBlipRotation(radiusBlip, 0)
     SetBlipColour(radiusBlip, 47)
+    SetBlipAlpha(radiusBlip, 100)
 
     local labelBlip = AddBlipForCoord(coords.x, coords.y, coords.z)
     SetBlipSprite(labelBlip, 597)


### PR DESCRIPTION
Added         SetBlipAlpha(radiusBlip, 100)

 as the radius blip is a solid colour, causing potential issues where the blip is over areas of the map that aren't in water and may block visibility. 

The radius is still crucial as it implies a general area where coral can be harvested.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
