### PR TITLE
fix: Fixed coral counting issues

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -9,6 +9,7 @@ ox_lib 'locale'
 
 shared_script {
     '@ox_lib/init.lua',
+    '@qbx_core/modules/lib.lua',
 }
 
 server_scripts {

--- a/server/main.lua
+++ b/server/main.lua
@@ -39,10 +39,7 @@ RegisterNetEvent('qbx_diving:server:sellCoral', function()
         end
     end
     if payout == 0 then
-        return lib.notify(src, {
-            type = 'error',
-            description = 'No coral to sell!',
-        })
+        return exports.qbx_core:Notify(locale('error.no_coral'), 'error')
     end
     player.Functions.AddMoney('cash', payout, 'sold-coral')
 end)
@@ -56,15 +53,6 @@ local function getNewLocation()
 end
 
 RegisterNetEvent('qbx_diving:server:takeCoral', function(coralIndex)
-    local function countTableKeys(tbl)
-        local count = 0
-        for _ in pairs(tbl) do
-            count = count + 1
-        end
-        return count
-    end
-    
-    print('coralIndex is ', coralIndex)
     if pickedUpCoralIndexes[coralIndex] then return end
     local src = source
     local coralType = config.coralTypes[math.random(1, #config.coralTypes)]
@@ -73,9 +61,9 @@ RegisterNetEvent('qbx_diving:server:takeCoral', function(coralIndex)
     exports.ox_inventory:AddItem(src, coralType.item, amount)
     pickedUpCoralIndexes[coralIndex] = true
     TriggerClientEvent('qbx_diving:client:coralTaken', -1, coralIndex)
-    TriggerEvent('qbx_diving:server:coralTaken', sharedConfig.coralLocations[currentAreaIndex].corals[coralIndex].coords)   
+    TriggerEvent('qbx_diving:server:coralTaken', sharedConfig.coralLocations[currentAreaIndex].corals[coralIndex].coords)
 
-    if countTableKeys(pickedUpCoralIndexes) == sharedConfig.coralLocations[currentAreaIndex].maxHarvestAmount then
+    if qbx.table.size(pickedUpCoralIndexes) == sharedConfig.coralLocations[currentAreaIndex].maxHarvestAmount then
         pickedUpCoralIndexes = {}
         currentAreaIndex = getNewLocation()
         TriggerClientEvent('qbx_diving:client:newLocationSet', -1, currentAreaIndex)

--- a/server/main.lua
+++ b/server/main.lua
@@ -39,7 +39,10 @@ RegisterNetEvent('qbx_diving:server:sellCoral', function()
         end
     end
     if payout == 0 then
-        return exports.qbx_core:Notify(locale('error.no_coral'), 'error')
+        return lib.notify(src, {
+            type = 'error',
+            description = 'No coral to sell!',
+        })
     end
     player.Functions.AddMoney('cash', payout, 'sold-coral')
 end)
@@ -53,6 +56,15 @@ local function getNewLocation()
 end
 
 RegisterNetEvent('qbx_diving:server:takeCoral', function(coralIndex)
+    local function countTableKeys(tbl)
+        local count = 0
+        for _ in pairs(tbl) do
+            count = count + 1
+        end
+        return count
+    end
+    
+    print('coralIndex is ', coralIndex)
     if pickedUpCoralIndexes[coralIndex] then return end
     local src = source
     local coralType = config.coralTypes[math.random(1, #config.coralTypes)]
@@ -61,8 +73,9 @@ RegisterNetEvent('qbx_diving:server:takeCoral', function(coralIndex)
     exports.ox_inventory:AddItem(src, coralType.item, amount)
     pickedUpCoralIndexes[coralIndex] = true
     TriggerClientEvent('qbx_diving:client:coralTaken', -1, coralIndex)
-    TriggerEvent('qbx_diving:server:coralTaken', sharedConfig.coralLocations[currentAreaIndex].corals[coralIndex].coords)
-    if #pickedUpCoralIndexes == sharedConfig.coralLocations[currentAreaIndex].maxHarvestAmount then
+    TriggerEvent('qbx_diving:server:coralTaken', sharedConfig.coralLocations[currentAreaIndex].corals[coralIndex].coords)   
+
+    if countTableKeys(pickedUpCoralIndexes) == sharedConfig.coralLocations[currentAreaIndex].maxHarvestAmount then
         pickedUpCoralIndexes = {}
         currentAreaIndex = getNewLocation()
         TriggerClientEvent('qbx_diving:client:newLocationSet', -1, currentAreaIndex)


### PR DESCRIPTION
## Description
When harvesting coral the amount harvested wasn't increasing, a new diving area would never be generated, and spawns would exhaust. 

This was because #pickedUpCoralIndexes doesn't track true/false updates.

## Checklist


- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
